### PR TITLE
Constrain numpy version; use pytest

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
   requires:
     - pytest
   commands:
-    - pytest ilastikrag/tests
+    - pytest -s --tb=native --pyargs ilastikrag.tests
   
   imports:
     - ilastikrag

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,8 +31,6 @@ requirements:
     - networkx >={{ networkx }}
 
 test:
-  source_files:
-    - ilastikrag/tests/*
   requires:
     - pytest
   commands:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
   requires:
     - pytest
   commands:
-    - pytest -s --tb=native --pyargs ilastikrag.tests
+    - ${PYTHON} -m pytest -s --tb=native --pyargs ilastikrag.tests
   
   imports:
     - ilastikrag

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - numpy  >={{ numpy }}
+    - numpy  >={{ numpy }},<1.15 # Until this is fixed: https://github.com/ukoethe/vigra/issues/436
     - h5py   >={{ h5py }}
     - pandas >={{ pandas }}
     - vigra  >={{ vigra }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python >=2.7
     - pip
 

--- a/ilastikrag/__init__.py
+++ b/ilastikrag/__init__.py
@@ -4,7 +4,3 @@ from . import accumulators
 from .accumulators import BaseEdgeAccumulator
 from .accumulators import BaseSpAccumulator
 from .rag import Rag
-
-# Convenient for running tests even after install:
-# nosetests ilastikrag.tests
-from . import tests

--- a/ilastikrag/tests/test_edgeregion_accumulator.py
+++ b/ilastikrag/tests/test_edgeregion_accumulator.py
@@ -159,10 +159,7 @@ class TestEdgeRegionEdgeAccumulator(object):
         try_bad_features(['edgeregion_edge_regionaxes_2z'])
     
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
-
-        
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])

--- a/ilastikrag/tests/test_rag.py
+++ b/ilastikrag/tests/test_rag.py
@@ -270,8 +270,7 @@ class TestRag(object):
         
 
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])

--- a/ilastikrag/tests/test_similarity_flatedge_accumulator.py
+++ b/ilastikrag/tests/test_similarity_flatedge_accumulator.py
@@ -48,8 +48,7 @@ class TestSimilarityFlatEdgeAccumulator(object):
         
 
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])

--- a/ilastikrag/tests/test_standard_accumulators.py
+++ b/ilastikrag/tests/test_standard_accumulators.py
@@ -318,8 +318,7 @@ class TestStandardAccumulators(object):
         assert list(features_df.columns.values) == ['sp1', 'sp2'] + edge_feature_names + sp_output_columns
 
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])

--- a/ilastikrag/tests/test_standard_flatedge_accumulator.py
+++ b/ilastikrag/tests/test_standard_flatedge_accumulator.py
@@ -92,8 +92,7 @@ class TestStandardFlatEdgeAccumulator(object):
 
 
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])

--- a/ilastikrag/tests/test_util.py
+++ b/ilastikrag/tests/test_util.py
@@ -59,8 +59,7 @@ def test_features_df_serialization():
         shutil.rmtree(tmpdir)
 
 if __name__ == "__main__":
-    import sys
-    import nose
-    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
-    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    import os
+    import pytest
+    module = os.path.split(__file__)[1][:-3]
+    pytest.main(['-s', '--tb=native', '--pyargs', f'ilastikrag.tests.{module}'])


### PR DESCRIPTION
Switches from `nosetests` to `pytest`.  This branch also contrains the `numpy` version to `<1.15`, due to ukoethe/vigra#436.