### PR TITLE
fix dtype of index for empty edge_labels

### DIFF
--- a/ilastikrag/tests/test_rag.py
+++ b/ilastikrag/tests/test_rag.py
@@ -49,6 +49,20 @@ class TestRag(object):
         default_features = itertools.chain(*default_features)
         assert set(rag.supported_features()) == set( default_features )
 
+    def test_superpixel_edges_only_in_y_direction(self):
+        superpixels = np.zeros((5, 6), dtype="uint32")
+        superpixels[0:2, ...] = 1
+        superpixels[2:, ...] = 2
+        superpixels = vigra.taggedView(superpixels, axistags="yx")
+        rag = Rag(superpixels)
+
+        dense_edge_tables = rag.dense_edge_tables
+        assert len(dense_edge_tables["x"]) == 0
+        assert isinstance(dense_edge_tables["x"].index, pd.Int64Index)
+
+        assert len(dense_edge_tables["y"]) == 6
+        assert isinstance(dense_edge_tables["y"].index, pd.Int64Index)
+
     def test_edge_decisions_from_groundtruth(self):
         # 1 2
         # 3 4


### PR DESCRIPTION
super artificial example, but it's my testdata in ilastik - super-pixel edges are only present in y-direction. So for x, the dense_edge_tables will be empty. Newer version of pandas seem to infer a default index dtype after of the index of the dataframe after merge 'object', which made difficulties when serializing.
I think it makes sense to always get the same dtype for the index.

Note: I checked and couldn't even find what the last pandas version is
that would support uint32 index. It will be pd.In64Index for any kind of
integers, so I removed the misleading naming and left a comment in the code.