### PR TITLE
fix default dtypes for columns

### DIFF
--- a/ilastikrag/rag.py
+++ b/ilastikrag/rag.py
@@ -332,11 +332,14 @@ class Rag(object):
         self._dense_edge_tables = OrderedDict()
         coord_cols = list(self._label_img.axistags.keys())
         column_labels = ['sp1', 'sp2', 'forwardness', 'edge_label'] + coord_cols
+        column_default_dtypes = [np.uint32, np.uint32, np.bool, np.uint32] + [np.uint16 for _ in coord_cols]
         for axiskey in dense_axes:
             edge_data = edge_datas[axiskey]
             n_edges = len(edge_data.ids)
             if n_edges == 0:
-                self._dense_edge_tables[axiskey] = pd.DataFrame(columns=column_labels, index=pd.Index([], dtype=np.int64))
+                self._dense_edge_tables[axiskey] = pd.DataFrame(
+                    {cname: pd.Series(dtype=dt) for cname, dt in zip(column_labels, column_default_dtypes)},
+                    index=pd.Index([], dtype=np.int64))
                 continue
             # TODO: investigate if ram could be saved by using a uint32 index
             # note that the merge will change the index again          

--- a/ilastikrag/tests/test_rag.py
+++ b/ilastikrag/tests/test_rag.py
@@ -63,6 +63,9 @@ class TestRag(object):
         assert len(dense_edge_tables["y"]) == 6
         assert isinstance(dense_edge_tables["y"].index, pd.Int64Index)
 
+        for column in dense_edge_tables["y"].columns:
+            assert dense_edge_tables["x"][column].dtype == dense_edge_tables["y"][column].dtype
+
     def test_edge_decisions_from_groundtruth(self):
         # 1 2
         # 3 4


### PR DESCRIPTION
pandas seems to have changed default to object - so defaulting to the
same column types one would find in a non-empty dataframe

on the same tip as #10, trying to get my test example in ilastik running :)