### PR TITLE
tackle numpy>1.19 + vigra issues

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - numpy >=1.12,<1.20
+    - numpy >=1.12,<2.0a
     - h5py
     - pandas >=0.25
     - vigra >=1.11

--- a/ilastikrag/tests/test_rag.py
+++ b/ilastikrag/tests/test_rag.py
@@ -74,13 +74,16 @@ class TestRag(object):
         vol1[ 0:10, 10:20] = 2
         vol1[10:20,  0:10] = 3
         vol1[10:20, 10:20] = 4
-        
-        vol1 = vigra.taggedView(vol1, 'yx')
-        rag = Rag(vol1)
-    
+
         # 2 3
         # 4 5
         vol2 = vol1.copy() + 1
+
+        # circumventing a incompatibility with vigra and numpy>1.19
+        # which was also fixed in newer vigra versions
+        vol1 = vigra.taggedView(vol1, 'yx')
+        vol2 = vigra.taggedView(vol2, 'yx')
+        rag = Rag(vol1)
 
         decisions = rag.edge_decisions_from_groundtruth(vol2)
         assert decisions.all()

--- a/ilastikrag/tests/test_standard_flatedge_accumulator.py
+++ b/ilastikrag/tests/test_standard_flatedge_accumulator.py
@@ -11,7 +11,7 @@ class TestStandardFlatEdgeAccumulator(object):
         # Create a volume of flat superpixels, where every slice 
         # is the same (except for the actual sp ids)
         num_sp_per_slice = 200
-        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice)
+        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice).view(np.ndarray)
          
         superpixels = np.zeros( shape=((10,) + slice_superpixels.shape), dtype=np.uint32 )
         for z in range(10):
@@ -32,7 +32,7 @@ class TestStandardFlatEdgeAccumulator(object):
         # Create a volume of flat superpixels, where every slice 
         # is the same (except for the actual sp ids)
         num_sp_per_slice = 200
-        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice)
+        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice).view(np.ndarray)
         
         superpixels = np.zeros( shape=((10,) + slice_superpixels.shape), dtype=np.uint32 )
         for z in range(10):
@@ -67,7 +67,7 @@ class TestStandardFlatEdgeAccumulator(object):
         # Create a volume of flat superpixels, where every slice
         # is the same (except for the actual sp ids)
         num_sp_per_slice = 200
-        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice)
+        slice_superpixels = generate_random_voronoi((100,200), num_sp_per_slice).view(np.ndarray)
         
         superpixels = np.zeros( shape=((10,) + slice_superpixels.shape), dtype=np.uint32 )
         for z in range(10):


### PR DESCRIPTION
not particularly proud having to make these changes, if there were new vigra versions instead of build number bumps on cf my life would be easier.

* unpin numpy to allow numpy>1.19
* add small fixes that avoid mixing vigra and numpy arrays.

the latest conda-forge build of vigra (1028) actually fixes the problem,
see: https://github.com/conda-forge/vigra-feedstock/commit/e0410d966d8c92422e82b24ca0a62f8fda49a532
still adding these fixes as limiting version by build number is not really
possible via meta.yaml.

the fix involves operating on numpy views in case of operations that involved both,
vigra and numpy arrays
