### PR TITLE
A little better default sizing

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,9 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - numpy >=1.12,<2.0a
+    # vigra/numpy incompatibility - related to indexing with a non-tuple sequence
+    # for multidimensional indexing;
+    - numpy >=1.12,<1.23
     - h5py
     - pandas >=0.25
     - vigra >=1.11

--- a/ilastikrag/gui/feature_selection_dialog.py
+++ b/ilastikrag/gui/feature_selection_dialog.py
@@ -52,7 +52,7 @@ class FeatureSelectionDialog(QDialog):
         parent
             *QWidget*
         """
-        super(FeatureSelectionDialog, self).__init__(parent)
+        super().__init__(parent)
         
         self.setWindowTitle("Select Edge Features")
         self.tree_widgets = {}
@@ -87,9 +87,11 @@ class FeatureSelectionDialog(QDialog):
         widget_layout.addWidget(buttonbox)
         self.setLayout(widget_layout)
 
-        total_spacing = self.width() - (len(channel_names)*checklist_widget.width())
-        total_width = total_spacing + len(channel_names) * ( 20 + checklist_widget.columnWidth(0) )
-        self.resize(total_width, 500)
+        desktopsize = QApplication.desktop().availableGeometry()
+        self.setMaximumSize(desktopsize.size())
+        self.setMinimumHeight(min(800, desktopsize.height()))
+
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     def selections(self):
         """


### PR DESCRIPTION
this is not a fix or anything, but maybe a slight improvement that will look
well enough for common cases (few channels, like 2-7 in total).

tested only on OSX so far - so let's see :)

I'll add screenshots for all platforms.

### OSX
#### Before (ilastik/ilastikrag:main)
<img width="852" alt="osx-screenshot-old" src="https://user-images.githubusercontent.com/24434157/188467139-baa1a8a9-e886-45a2-91a0-5e8e84131cb2.png">

#### After (this PR)
<img width="1472" alt="osx-screenshot-new" src="https://user-images.githubusercontent.com/24434157/188467236-06d9729b-dd60-41fd-ab1d-0e5f8f87d7cf.png">

### Windows
#### Before (ilastik/ilastikrag:main)
![old_dlg](https://user-images.githubusercontent.com/24434157/188467477-23bae04c-f02c-4214-9777-0bad78053904.PNG)

#### After (this PR)
![new_dlg](https://user-images.githubusercontent.com/24434157/188467484-946c8923-8c45-4593-a197-3673c844b8de.PNG)

### Linux
#### Before (ilastik/ilastikrag:main)
![before](https://user-images.githubusercontent.com/24434157/188499974-6a214a53-6211-4476-82c7-e5ba003cd462.png)

#### After (this PR)
![after](https://user-images.githubusercontent.com/24434157/188500049-861cb930-2bb9-4622-8679-b88b0fb706a8.png)


ref for vigra fix: https://github.com/conda-forge/vigra-feedstock/pull/95