### PR TITLE
quality of life improvement: Add reset button

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: install xvfb/deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yy mesa-utils libgl1-mesa-dev xvfb curl
       - name: setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -24,4 +28,5 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -n base -c conda-forge mamba boa -y
-          mamba build -c conda-forge conda-recipe
+          xvfb-run --server-args="-screen 0 1024x768x24" conda mambabuild --override-channels \
+          -c conda-forge conda-recipe

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,6 +34,8 @@ requirements:
 test:
   requires:
     - pytest
+    - pytest-qt
+    - pyqt >5.6
   commands:
     - pytest .
 

--- a/ilastikrag/gui/feature_selection_dialog.py
+++ b/ilastikrag/gui/feature_selection_dialog.py
@@ -23,15 +23,15 @@ class FeatureSelectionDialog(QDialog):
                          'standard_sp_mean', 'standard_sp_count',
                          'standard_edge_quantiles', 'standard_edge_quantiles_10', 'standard_edge_quantiles_90']
 
-        default_selections = { 'Grayscale': ['standard_sp_mean', 'standard_sp_count'],
+        initial_selections = { 'Grayscale': ['standard_sp_mean', 'standard_sp_count'],
                                'Membranes': ['standard_edge_quantiles'] }
 
-        dlg = FeatureSelectionDialog(channel_names, feature_names, default_selections)
+        dlg = FeatureSelectionDialog(channel_names, feature_names, initial_selections)
         dlg.exec_()
         if dlg.exec_() == QDialog.Accepted:
             print dlg.selections()
     """
-    def __init__(self, channel_names, feature_names, default_selections=None, parent=None):
+    def __init__(self, channel_names, feature_names, initial_selections=None, default_selections=None, parent=None):
         """
         Parameters
         ----------
@@ -44,11 +44,17 @@ class FeatureSelectionDialog(QDialog):
             Feature names, exactly as expected by :py:meth:`~ilastikrag.rag.Rag.compute_features()`.
             The features will be grouped by category and shown in duplicate checklist widgets for each channel.
         
+        initial_selections
+            *dict, str: list-of-str*
+            Mapping from channel_name -> feature_names, indicating which
+            features should be selected when opening the dialog for each channel.
+        
         default_selections
             *dict, str: list-of-str*
             Mapping from channel_name -> feature_names, indicating which
             features should be selected by default for each channel.
-        
+            Clicking the reset button, will switch to these selected features.
+
         parent
             *QWidget*
         """
@@ -61,8 +67,8 @@ class FeatureSelectionDialog(QDialog):
         boxes_layout = QHBoxLayout()
         for channel_name in channel_names:
             default_checked = []
-            if default_selections and channel_name in default_selections:
-                default_checked = default_selections[channel_name]
+            if initial_selections and channel_name in initial_selections:
+                default_checked = initial_selections[channel_name]
             checklist = _make_checklist(feature_names, default_checked)
             checklist.name = channel_name
             checklist_widget = HierarchicalChecklistView( checklist, parent=self )
@@ -90,7 +96,7 @@ class FeatureSelectionDialog(QDialog):
         resetButton = QPushButton("Reset")
         resetButton.setToolTip("Reset feature selections to default")
 
-        resetButton.setEnabled(default_selections and channel_name in default_selections)
+        resetButton.setEnabled(bool(default_selections) and channel_name in default_selections)
         resetButton.clicked.connect(_reset_models_to_default)
         buttonbox.addButton(resetButton, QDialogButtonBox.ResetRole)
         resetButton.clicked.connect(_reset_models_to_default)
@@ -132,12 +138,12 @@ class FeatureSelectionDialog(QDialog):
         return selections
 
     @classmethod
-    def launch(cls, channel_names, feature_names, default_selections=None):
+    def launch(cls, channel_names, feature_names, initial_selections, default_selections=None):
         from PyQt5.QtWidgets import QApplication
         if QApplication.instance() is None:
             app = QApplication([])
         
-        dlg = FeatureSelectionDialog(channel_names, feature_names, default_selections)
+        dlg = FeatureSelectionDialog(channel_names, feature_names, initial_selections, default_selections)
         dlg.show()
         dlg.raise_()
         dlg.exec_()
@@ -206,20 +212,23 @@ if __name__ == "__main__":
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+    from PyQt5.QtWidgets import QApplication
+    app = QApplication([])
     #channel_names = ['Grayscale', 'Membranes', 'Cytoplasm', 'Mitochondria']
     channel_names = ['Grayscale', 'Membranes']
     feature_names = ['standard_edge_mean', 'standard_edge_maximum', 'standard_edge_count',
                      'standard_sp_mean', 'standard_sp_maximum', 'standard_sp_count',
                      'standard_edge_quantiles', 'standard_edge_quantiles_10', 'standard_edge_quantiles_90']
 
-    default_selections = { 'Grayscale': ['standard_sp_mean', 'standard_sp_count'],
+    initial_selections = { 'Grayscale': ['standard_sp_mean', 'standard_sp_count'],
                            'Membranes': ['standard_edge_quantiles'] }
 
-    selections = FeatureSelectionDialog.launch(channel_names, feature_names, default_selections)
+    default_selections = { 'Grayscale': ['standard_edge'],
+                           'Membranes': ['standard_edge_quantiles_10', 'standard_edge_quantiles_90'] }
+
+    selections = FeatureSelectionDialog.launch(channel_names, feature_names, initial_selections, default_selections)
     print(selections)
 
-#     from PyQt5.QtWidgets import QApplication
-#     app = QApplication([])
 # 
 # 
 #     dlg = FeatureSelectionDialog(

--- a/ilastikrag/gui/feature_selection_dialog.py
+++ b/ilastikrag/gui/feature_selection_dialog.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from itertools import groupby
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QDialogButtonBox, QSizePolicy
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QDialogButtonBox, QSizePolicy, QPushButton
 
 from .util import HierarchicalChecklistView, Checklist
 
@@ -73,6 +73,27 @@ class FeatureSelectionDialog(QDialog):
         buttonbox.setStandardButtons( QDialogButtonBox.Ok | QDialogButtonBox.Cancel )
         buttonbox.accepted.connect( self.accept )
         buttonbox.rejected.connect( self.reject )
+
+        resetButton = QPushButton("Reset")
+
+        def _reset_models_to_default():
+
+            for channel_name in channel_names:
+                default_checked = []
+                if default_selections and channel_name in default_selections:
+                    default_checked = default_selections[channel_name]
+
+                checklist = _make_checklist(feature_names, default_checked)
+                checklist.name = channel_name
+                self.checklist_widgets[channel_name].setModel(checklist)
+
+        resetButton = QPushButton("Reset")
+        resetButton.setToolTip("Reset feature selections to default")
+
+        resetButton.setEnabled(default_selections and channel_name in default_selections)
+        resetButton.clicked.connect(_reset_models_to_default)
+        buttonbox.addButton(resetButton, QDialogButtonBox.ResetRole)
+        resetButton.clicked.connect(_reset_models_to_default)
 
         widget_layout = QVBoxLayout()
 

--- a/ilastikrag/gui/feature_selection_dialog.py
+++ b/ilastikrag/gui/feature_selection_dialog.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from itertools import groupby
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QDialogButtonBox, QSizePolicy, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QDialogButtonBox, QSizePolicy, QPushButton, QApplication
 
 from .util import HierarchicalChecklistView, Checklist
 
@@ -100,7 +100,6 @@ class FeatureSelectionDialog(QDialog):
         resetButton.clicked.connect(_reset_models_to_default)
         buttonbox.addButton(resetButton, QDialogButtonBox.ResetRole)
         resetButton.clicked.connect(_reset_models_to_default)
-
         widget_layout = QVBoxLayout()
 
         # FIXME: Would like to hold the TreeWidgets in a QScrollArea,
@@ -119,6 +118,9 @@ class FeatureSelectionDialog(QDialog):
         self.setMinimumHeight(min(800, desktopsize.height()))
 
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        # for easy access in testing
+        self._resetButton = resetButton
 
     def selections(self):
         """

--- a/ilastikrag/gui/util/hierarchical_checklist_view.py
+++ b/ilastikrag/gui/util/hierarchical_checklist_view.py
@@ -18,14 +18,7 @@ class HierarchicalChecklistView(QTreeView):
     """
     def __init__(self, checklist, parent=None):
         super(HierarchicalChecklistView, self).__init__(parent)
-        self.setModel( HierarchicalChecklistModel(checklist) )
-        self.setItemDelegate( HierarchicalChecklistViewDelegate(self) )
-        
-        # Open a persistent editor for every item
-        self.open_persistent_editors_for_children(self.model().invisibleRootItem())
-        self.expandAll()
-        
-        self.model().setHorizontalHeaderLabels([self.model()._checklist.name])
+        self.setModel(checklist)
 
     def open_persistent_editors_for_children(self, item):
         model_index = self.model().indexFromItem(item)
@@ -44,6 +37,15 @@ class HierarchicalChecklistView(QTreeView):
         # (E.g. QDialog can accept/reject the dialog when the user presses 'enter' or 'esc'.)
         if  event.type() == QEvent.KeyPress:
             event.ignore()
+
+    def setModel(self, checklist):
+        super().setModel(HierarchicalChecklistModel(checklist))
+        self.setItemDelegate(HierarchicalChecklistViewDelegate(self))
+
+        # Open a persistent editor for every item
+        self.open_persistent_editors_for_children(self.model().invisibleRootItem())
+        self.expandAll()
+        self.model().setHorizontalHeaderLabels([self.model()._checklist.name])
 
 class Checklist(object):
     """

--- a/ilastikrag/tests/test_gui.py
+++ b/ilastikrag/tests/test_gui.py
@@ -1,0 +1,76 @@
+import pytest
+from PyQt5.QtCore import Qt
+
+from ilastikrag.gui.feature_selection_dialog import FeatureSelectionDialog
+
+
+@pytest.fixture
+def channel_names():
+    return ["Grayscale", "Membranes"]
+
+
+@pytest.fixture
+def feature_names():
+    return [
+        "standard_edge_mean",
+        "standard_edge_maximum",
+        "standard_edge_count",
+        "standard_sp_mean",
+        "standard_sp_maximum",
+        "standard_sp_count",
+        "standard_edge_quantiles_10",
+        "standard_edge_quantiles_90",
+    ]
+
+
+@pytest.fixture
+def initial_selections():
+    return {
+        "Grayscale": ["standard_edge_mean"],
+        "Membranes": [
+            "standard_edge_quantiles_10",
+            "standard_edge_quantiles_90",
+        ],
+    }
+
+
+@pytest.fixture
+def default_selections():
+    return {
+        "Grayscale": ["standard_edge_maximum"],
+        "Membranes": [
+            "standard_edge_count",
+            "standard_edge_quantiles_90",
+            "standard_sp_mean",
+        ],
+    }
+
+
+def test_no_features(qtbot, channel_names, feature_names):
+    dlg = FeatureSelectionDialog(channel_names, feature_names)
+    qtbot.addWidget(dlg)
+    dlg.accept()
+
+    assert dlg.selections() == {"Grayscale": [], "Membranes": []}
+
+
+def test_initial_selection(qtbot, channel_names, feature_names, initial_selections):
+    dlg = FeatureSelectionDialog(channel_names, feature_names, initial_selections)
+    qtbot.addWidget(dlg)
+    dlg.accept()
+
+    assert dlg.selections() == initial_selections
+
+
+def test_reset_to_defaults(
+    qtbot, channel_names, feature_names, initial_selections, default_selections
+):
+    dlg = FeatureSelectionDialog(
+        channel_names, feature_names, initial_selections, default_selections
+    )
+    qtbot.addWidget(dlg)
+    qtbot.mouseClick(dlg._resetButton, Qt.LeftButton)
+    dlg.accept()
+
+    assert dlg.selections() != initial_selections
+    assert dlg.selections() == default_selections


### PR DESCRIPTION
it will be very useful in ilastik to be able to reset to some default set of features (with the pending rework of the new, simplified dialog.

the signature (when using args) has not changed (it has however when using kwargs). I chose to rename the `default_selections` parameter, as it was used, to `initial_selections` (e.g. loaded from a project file/slot), as to reflect the semantic meaning, especially in conjunction with `default_selections` that can now be used to reset the feature selection.

xref: https://github.com/ilastik/ilastik/issues/2546